### PR TITLE
Do not stumble on leading backslash when using class names to identify messages

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterHandlers.php
+++ b/src/DependencyInjection/Compiler/RegisterHandlers.php
@@ -52,7 +52,7 @@ class RegisterHandlers implements CompilerPassInterface
                     $callable = $serviceId;
                 }
 
-                $handlers[$key] = $callable;
+                $handlers[ltrim($key, '\\')] = $callable;
             }
         );
 

--- a/src/DependencyInjection/Compiler/RegisterSubscribers.php
+++ b/src/DependencyInjection/Compiler/RegisterSubscribers.php
@@ -52,7 +52,7 @@ class RegisterSubscribers implements CompilerPassInterface
                     $callable = $serviceId;
                 }
 
-                $handlers[$key][] = $callable;
+                $handlers[ltrim($key, '\\')][] = $callable;
             }
         );
 


### PR DESCRIPTION
fix #22
