### PR TITLE
Append subscribers instead of replacing them

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterSubscribers.php
+++ b/src/DependencyInjection/Compiler/RegisterSubscribers.php
@@ -39,7 +39,7 @@ class RegisterSubscribers implements CompilerPassInterface
 
         $definition = $container->findDefinition($this->serviceId);
 
-        $handlers = array();
+        $handlers = $definition->getArgument(0);
 
         $this->collectServiceIds(
             $container,


### PR DESCRIPTION
Append tagged subscribers instead of replacing them. This allows other code (e.g. custom compiler passes) to also add their own event subscribers.
