### PR TITLE
quote special characters in YAML config files

### DIFF
--- a/src/Resources/config/command_bus.yml
+++ b/src/Resources/config/command_bus.yml
@@ -12,7 +12,7 @@ services:
         class: SimpleBus\Message\Handler\DelegatesToMessageHandlerMiddleware
         public: false
         arguments:
-            - @simple_bus.command_bus.command_handler_resolver
+            - '@simple_bus.command_bus.command_handler_resolver'
         tags:
             - { name: command_bus_middleware, priority: -1000 }
 
@@ -28,7 +28,7 @@ services:
         class: SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver
         public: false
         arguments:
-            - [@service_container, 'get']
+            - ['@service_container', 'get']
 
     simple_bus.command_bus.command_handler_map:
         class: SimpleBus\Message\CallableResolver\CallableMap
@@ -36,14 +36,14 @@ services:
         arguments:
             # collection of command handler service ids, will be provided by the RegisterHandlers compiler pass
             - []
-            - @simple_bus.command_bus.callable_resolver
+            - '@simple_bus.command_bus.callable_resolver'
 
     simple_bus.command_bus.command_handler_resolver:
         class: SimpleBus\Message\Handler\Resolver\NameBasedMessageHandlerResolver
         public: false
         arguments:
-            - @simple_bus.command_bus.command_name_resolver
-            - @simple_bus.command_bus.command_handler_map
+            - '@simple_bus.command_bus.command_name_resolver'
+            - '@simple_bus.command_bus.command_handler_map'
 
     simple_bus.command_bus.finishes_command_before_handling_next_middleware:
         class: SimpleBus\Message\Bus\Middleware\FinishesHandlingMessageBeforeHandlingNext

--- a/src/Resources/config/command_bus_logging.yml
+++ b/src/Resources/config/command_bus_logging.yml
@@ -6,7 +6,7 @@ services:
         class: SimpleBus\Message\Logging\LoggingMiddleware
         public: false
         arguments:
-            - @logger
+            - '@logger'
             - %simple_bus.command_bus.logging.level%
         tags:
             - { name: command_bus_middleware, priority: -999 }

--- a/src/Resources/config/doctrine_orm_bridge.yml
+++ b/src/Resources/config/doctrine_orm_bridge.yml
@@ -3,7 +3,7 @@ services:
         class: SimpleBus\DoctrineORMBridge\MessageBus\WrapsMessageHandlingInTransaction
         public: false
         arguments:
-            - @doctrine
+            - '@doctrine'
             - %simple_bus.doctrine_orm_bridge.entity_manager%
 
     # for BC

--- a/src/Resources/config/event_bus.yml
+++ b/src/Resources/config/event_bus.yml
@@ -35,7 +35,7 @@ services:
         class: SimpleBus\Message\Subscriber\NotifiesMessageSubscribersMiddleware
         public: false
         arguments:
-            - @simple_bus.event_bus.event_subscribers_resolver
+            - '@simple_bus.event_bus.event_subscribers_resolver'
             - ~ # can be a logger, may be provided by EventBusExtension when logging enabled
             - ~ # can be the logging level, may be provided by EventBusExtension when logging enabled
         tags:
@@ -53,7 +53,7 @@ services:
         class: SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver
         public: false
         arguments:
-            - [@service_container, 'get']
+            - ['@service_container', 'get']
 
     simple_bus.event_bus.event_subscribers_collection:
         class: SimpleBus\Message\CallableResolver\CallableCollection
@@ -61,18 +61,18 @@ services:
         arguments:
             # collection of event subscriber services ids, will be provided by the RegisterSubscribers compiler pas
             - []
-            - @simple_bus.event_bus.callable_resolver
+            - '@simple_bus.event_bus.callable_resolver'
 
     simple_bus.event_bus.event_subscribers_resolver:
         class: SimpleBus\Message\Subscriber\Resolver\NameBasedMessageSubscriberResolver
         public: false
         arguments:
-            - @simple_bus.event_bus.event_name_resolver
-            - @simple_bus.event_bus.event_subscribers_collection
+            - '@simple_bus.event_bus.event_name_resolver'
+            - '@simple_bus.event_bus.event_subscribers_collection'
 
     simple_bus.event_bus.handles_recorded_mesages_middleware:
         class: SimpleBus\Message\Recorder\HandlesRecordedMessagesMiddleware
         public: false
         arguments:
-            - @simple_bus.event_bus.aggregates_recorded_messages
-            - @simple_bus.event_bus
+            - '@simple_bus.event_bus.aggregates_recorded_messages'
+            - '@simple_bus.event_bus'

--- a/src/Resources/config/event_bus_logging.yml
+++ b/src/Resources/config/event_bus_logging.yml
@@ -6,7 +6,7 @@ services:
         class: SimpleBus\Message\Logging\LoggingMiddleware
         public: false
         arguments:
-            - @logger
+            - '@logger'
             - %simple_bus.event_bus.logging.level%
         tags:
             - { name: event_bus_middleware, priority: -999 }


### PR DESCRIPTION
The `@` character is reserved in the YAML specs and therefore should
not be used as the first character in an unquoted scalar value.

This fixes #31.
