### PR TITLE
Fix typo handles_recorded_mesages_middleware

### DIFF
--- a/src/Resources/config/event_bus.yml
+++ b/src/Resources/config/event_bus.yml
@@ -70,7 +70,7 @@ services:
             - '@simple_bus.event_bus.event_name_resolver'
             - '@simple_bus.event_bus.event_subscribers_collection'
 
-    simple_bus.event_bus.handles_recorded_mesages_middleware:
+    simple_bus.event_bus.handles_recorded_messages_middleware:
         class: SimpleBus\Message\Recorder\HandlesRecordedMessagesMiddleware
         public: false
         arguments:

--- a/src/Resources/config/event_bus.yml
+++ b/src/Resources/config/event_bus.yml
@@ -76,3 +76,7 @@ services:
         arguments:
             - '@simple_bus.event_bus.aggregates_recorded_messages'
             - '@simple_bus.event_bus'
+    
+    simple_bus.event_bus.handles_recorded_mesages_middleware:
+        alias: simple_bus.event_bus.handles_recorded_messages_middleware
+        public: false

--- a/src/SimpleBusEventBusBundle.php
+++ b/src/SimpleBusEventBusBundle.php
@@ -51,7 +51,7 @@ class SimpleBusEventBusBundle extends Bundle
         CompilerPassUtil::prependBeforeOptimizationPass(
             $container,
             new AddMiddlewareTags(
-                'simple_bus.event_bus.handles_recorded_mesages_middleware',
+                'simple_bus.event_bus.handles_recorded_messages_middleware',
                 ['command'],
                 200
             )


### PR DESCRIPTION
Changes the service id `simple_bus.event_bus.handles_recorded_mesages_middleware` in `simple_bus.event_bus.handles_recorded_messages_middleware`
