### PR TITLE
Symfony 3.1 deprecation notice (quoting a scalar starting with the "%" indicator character)

### DIFF
--- a/src/Resources/config/command_bus_logging.yml
+++ b/src/Resources/config/command_bus_logging.yml
@@ -7,7 +7,7 @@ services:
         public: false
         arguments:
             - '@logger'
-            - %simple_bus.command_bus.logging.level%
+            - '%simple_bus.command_bus.logging.level%'
         tags:
             - { name: command_bus_middleware, priority: -999 }
             - { name: monolog.logger, channel: command_bus }

--- a/src/Resources/config/doctrine_orm_bridge.yml
+++ b/src/Resources/config/doctrine_orm_bridge.yml
@@ -4,7 +4,7 @@ services:
         public: false
         arguments:
             - '@doctrine'
-            - %simple_bus.doctrine_orm_bridge.entity_manager%
+            - '%simple_bus.doctrine_orm_bridge.entity_manager%'
 
     # for BC
     simple_bus.doctrine_orm_bridge.aggregates_multiple_event_providers:

--- a/src/Resources/config/event_bus_logging.yml
+++ b/src/Resources/config/event_bus_logging.yml
@@ -7,7 +7,7 @@ services:
         public: false
         arguments:
             - '@logger'
-            - %simple_bus.event_bus.logging.level%
+            - '%simple_bus.event_bus.logging.level%'
         tags:
             - { name: event_bus_middleware, priority: -999 }
             - { name: monolog.logger, channel: event_bus }


### PR DESCRIPTION
Hello,

This pull request only fixes a Symfony 3.1 deprecation notice:

> Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0

It's my first PR on GitHub, please feel free to comment if I did something wrong.

Thank you,
Artem
