### PR TITLE
Add subscribers autowiring feature

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterAutowiredSubscribers.php
+++ b/src/DependencyInjection/Compiler/RegisterAutowiredSubscribers.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\DependencyInjection\Compiler;
+
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+use SimpleBus\Message\Name\NamedMessage;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ *
+ */
+final class RegisterAutowiredSubscribers implements CompilerPassInterface
+{
+    private $serviceId;
+    private $autowiredSubscriberTag;
+    private $manualSubscriberTag;
+
+    /**
+     * @param string  $serviceId              The service id of the MessageSubscriberCollection
+     * @param string  $autowiredSubscriberTag The tag name of autowired message subscriber services
+     * @param string  $manualSubscriberTag    The tag name of manual message subscriber services
+     */
+    public function __construct($serviceId, $autowiredSubscriberTag, $manualSubscriberTag)
+    {
+        $this->serviceId = $serviceId;
+        $this->autowiredSubscriberTag = $autowiredSubscriberTag;
+        $this->manualSubscriberTag = $manualSubscriberTag;
+    }
+
+    /**
+     * Search for message autowired subscriber services and provide them as a constructor argument to the message subscriber
+     * collection service.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has($this->serviceId)) {
+            return;
+        }
+
+        $definition = $container->findDefinition($this->serviceId);
+
+        $handlers = $definition->getArgument(0);
+
+        foreach ($container->findTaggedServiceIds($this->autowiredSubscriberTag) as $serviceId => $tags) {
+            if (count($tags) > 1) {
+                throw new RuntimeException(
+                    sprintf('Service "%s" must contain the only "%s" tag.', $serviceId, $this->autowiredSubscriberTag)
+                );
+            }
+
+            $tag = $tags[0];
+
+            $subscriberDefinition = $container->getDefinition($serviceId);
+
+            if ($subscriberDefinition->hasTag($this->manualSubscriberTag)) {
+                throw new RuntimeException(
+                    sprintf('Service "%s" must contain either "%s" or "%s" tag, not both of them.', $serviceId, $tag, $this->manualSubscriberTag)
+                );
+            }
+
+            if (!$subscriberDefinition->getClass()) {
+                throw new RuntimeException(
+                    sprintf('Class is missing in the "%s" service.', $serviceId)
+                );
+            }
+
+            $handlers = array_merge_recursive(
+                $handlers,
+                $this->getHandlersFrom(new ReflectionClass($subscriberDefinition->getClass()), $serviceId)
+            );
+        }
+
+        $definition->replaceArgument(0, $handlers);
+    }
+
+    private function getHandlersFrom(ReflectionClass $class, $serviceId)
+    {
+        $handlers = [];
+
+        foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if (
+                $method->getNumberOfParameters() !== 1
+                || !$method->getParameters()[0]->getClass()
+            ) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Method "%s::%s" in service "%s" contains inappropriate public method for autowiring.'
+                        . ' You can try to register your subscribers manually with the "%s" tag.',
+                        $class->getName(),
+                        $method->getName(),
+                        $serviceId,
+                        $this->manualSubscriberTag
+                    )
+                );
+            }
+
+            $eventClass = $method->getParameters()[0]->getClass();
+
+            if ($eventClass->implementsInterface(NamedMessage::class)) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Event "%s" is incompatible with autowiring feature because it implements the %s in service "%s".'
+                        . ' You can try to register your subscribers manually with the "%s" tag.',
+                        $eventClass->getName(),
+                        NamedMessage::class,
+                        $serviceId,
+                        $this->manualSubscriberTag
+                    )
+                );
+            }
+
+            $handlers[$eventClass->getName()][] = [$serviceId, $method->getName()];
+        }
+
+        return $handlers;
+    }
+}

--- a/src/DependencyInjection/Compiler/RegisterSubscribers.php
+++ b/src/DependencyInjection/Compiler/RegisterSubscribers.php
@@ -39,7 +39,7 @@ class RegisterSubscribers implements CompilerPassInterface
 
         $definition = $container->findDefinition($this->serviceId);
 
-        $handlers = array();
+        $handlers = $definition->getArgument(0);
 
         $this->collectServiceIds(
             $container,

--- a/src/SimpleBusEventBusBundle.php
+++ b/src/SimpleBusEventBusBundle.php
@@ -5,6 +5,7 @@ namespace SimpleBus\SymfonyBridge;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\AddMiddlewareTags;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\CompilerPassUtil;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\ConfigureMiddlewares;
+use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterAutowiredSubscribers;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterMessageRecorders;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterSubscribers;
 use SimpleBus\SymfonyBridge\DependencyInjection\EventBusExtension;
@@ -45,6 +46,14 @@ class SimpleBusEventBusBundle extends Bundle
                 'simple_bus.event_bus.event_subscribers_collection',
                 'event_subscriber',
                 'subscribes_to'
+            )
+        );
+
+        $container->addCompilerPass(
+            new RegisterAutowiredSubscribers(
+                'simple_bus.event_bus.event_subscribers_collection',
+                'event_subscriber_autowired',
+                'event_subscriber'
             )
         );
 

--- a/tests/Functional/AutowiringTest.php
+++ b/tests/Functional/AutowiringTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional;
+
+use SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest\SendEmailVerificationInstructionsSubscriber;
+use SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest\UserChangedEmail;
+use SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest\UserRegistered;
+
+/**
+ *
+ */
+final class AutowiringTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_registers_and_handlers_autowired_subscribers()
+    {
+        $kernel = new TestKernel('test', true, 'autowiring', __DIR__ . '/AutowiringTest/config.yml');
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $eventBus = $container->get('event_bus');
+        $eventBus->handle(new UserRegistered(42));
+        $eventBus->handle(new UserChangedEmail(42));
+
+        $subscriber = $container->get('test_event_subscriber');
+        /** @var $subscriber SendEmailVerificationInstructionsSubscriber */
+
+        $this->assertTrue($subscriber->userRegisteredHandled);
+        $this->assertTrue($subscriber->userChangedEmailHandled);
+    }
+}

--- a/tests/Functional/AutowiringTest/SendEmailVerificationInstructionsSubscriber.php
+++ b/tests/Functional/AutowiringTest/SendEmailVerificationInstructionsSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest;
+
+/**
+ *
+ */
+final class SendEmailVerificationInstructionsSubscriber
+{
+    public $userRegisteredHandled = false;
+    public $userChangedEmailHandled = false;
+
+    public function onUserRegistered(UserRegistered $event)
+    {
+        $this->userRegisteredHandled = true;
+    }
+
+    public function onUserChangedEmail(UserChangedEmail $event)
+    {
+        $this->userChangedEmailHandled = true;
+    }
+}

--- a/tests/Functional/AutowiringTest/UserChangedEmail.php
+++ b/tests/Functional/AutowiringTest/UserChangedEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest;
+
+/**
+ *
+ */
+final class UserChangedEmail
+{
+    private $userId;
+
+    /**
+     * @param int $userId
+     */
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+}

--- a/tests/Functional/AutowiringTest/UserRegistered.php
+++ b/tests/Functional/AutowiringTest/UserRegistered.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest;
+
+/**
+ *
+ */
+final class UserRegistered
+{
+    private $userId;
+
+    /**
+     * @param int $userId
+     */
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+}

--- a/tests/Functional/AutowiringTest/config.yml
+++ b/tests/Functional/AutowiringTest/config.yml
@@ -1,0 +1,18 @@
+services:
+    test_event_subscriber:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\AutowiringTest\SendEmailVerificationInstructionsSubscriber
+        tags:
+            - { name: event_subscriber_autowired }
+
+event_bus:
+    event_name_resolver_strategy: class_based
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        path: :memory:
+        memory: true
+    orm:
+        entity_managers:
+            default:
+                connection: default

--- a/tests/Functional/SmokeTest.php
+++ b/tests/Functional/SmokeTest.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommand;
-use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestKernel;
+use SimpleBus\SymfonyBridge\Tests\Functional\TestKernel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SmokeTest extends \PHPUnit_Framework_TestCase
@@ -15,7 +15,7 @@ class SmokeTest extends \PHPUnit_Framework_TestCase
      */
     public function it_handles_a_command_then_dispatches_events_for_all_modified_entities()
     {
-        $kernel = new TestKernel('test', true);
+        $kernel = new TestKernel('test', true, 'smoke', __DIR__ . '/SmokeTest/config.yml');
         $kernel->boot();
         $container = $kernel->getContainer();
 

--- a/tests/Functional/SmokeTest/config.yml
+++ b/tests/Functional/SmokeTest/config.yml
@@ -30,8 +30,6 @@ services:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherEventSubscriber
         tags:
             - { name: event_subscriber, subscribes_to: some_other_event }
-        arguments:
-            - '@command_bus'
 
 doctrine:
     dbal:
@@ -45,7 +43,7 @@ doctrine:
                 mappings:
                     test:
                         type: annotation
-                        dir: "%kernel.root_dir%/Entity/"
+                        dir: "%kernel.root_dir%/SmokeTest/Entity/"
                         prefix: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Entity
                         alias: Test
                         is_bundle: false

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
+namespace SimpleBus\SymfonyBridge\Tests\Functional;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use SimpleBus\SymfonyBridge\SimpleBusCommandBusBundle;
@@ -13,13 +13,17 @@ use Symfony\Component\HttpKernel\Kernel;
 class TestKernel extends Kernel
 {
     private $tempDir;
+    private $configPath;
 
-    public function __construct($environment, $debug)
+    public function __construct($environment, $debug, $name, $configPath)
     {
         parent::__construct($environment, $debug);
 
         $this->tempDir = sys_get_temp_dir() . '/' . uniqid();
         mkdir($this->tempDir, 0777, true);
+
+        $this->name = $name;
+        $this->configPath = $configPath;
     }
 
     public function registerBundles()
@@ -35,7 +39,7 @@ class TestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__ . '/config.yml');
+        $loader->load($this->configPath);
     }
 
     public function getCacheDir()


### PR DESCRIPTION
This is a draft of autowiring feature described in #39.

Some notes:
* for consistency with regular `subscribes_to`, this feature doesn't explicitly disallows non-final events; one might think that if you type-hinted against an interface or abstract/inheritable event class, you'd also subscribe all the children, but that's not the case;
* since `event_name_resolver_strategy` is a global flag, I couldn't find way to test feature in the SmokeTest, so it has separate test case.

Example of configuration:
```yml
services:
    send_email_verification_instructions_subscriber:
        class: Acme\SendEmailVerificationInstructionsSubscriber
        tags:
            - { name: event_subscriber_autowired }
```