### PR TITLE
Drop support for php 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,28 @@
-language: php
-
 sudo: false
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+language: php
 
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION="2.3.*"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.4.*"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.5.*"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.6.*"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.7.*"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.8.*@dev"
-    - php: 5.6
-      env: SYMFONY_VERSION="3.0.*@dev"
+    - php: 7.0
+    - php: 7.1
+      env: SYMFONY_VERSION=2.7.*
+    - php: 7.1
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.3.*
+
+env:
+  global:
+    - SYMFONY_VERSION=""
 
 before_install:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/http-kernel:$SYMFONY_VERSION symfony/dependency-injection:$SYMFONY_VERSION symfony/yaml:$SYMFONY_VERSION symfony/config:$SYMFONY_VERSION symfony/monolog-bridge:$SYMFONY_VERSION symfony/doctrine-bridge:$SYMFONY_VERSION; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/http-kernel:$SYMFONY_VERSION symfony/dependency-injection:$SYMFONY_VERSION symfony/yaml:$SYMFONY_VERSION symfony/config:$SYMFONY_VERSION symfony/monolog-bridge:$SYMFONY_VERSION; fi
 
 install:
-  - composer update --prefer-dist
+  - composer install --prefer-dist
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.6 || ^7.0",
         "simple-bus/message-bus": "~2.0",
-        "symfony/http-kernel": "~2.3|~3.0",
-        "symfony/dependency-injection": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "symfony/config": "~2.3|~3.0"
+        "symfony/http-kernel": "~2.3 || ~3.0",
+        "symfony/dependency-injection": "~2.3 || ~3.0",
+        "symfony/yaml": "~2.3 || ~3.0",
+        "symfony/config": "~2.3 || ~3.0"
     },
     "suggest": {
         "simple-bus/doctrine-orm-bridge": "For integration with Doctrine ORM",
@@ -35,8 +35,8 @@
         "simple-bus/doctrine-orm-bridge": "~4.0",
         "doctrine/orm": "~2.3",
         "doctrine/doctrine-bundle": "~1.0",
-        "symfony/monolog-bridge": "~2.3|~3.0",
-        "symfony/monolog-bundle": "~2.3|~3.0"
+        "symfony/monolog-bridge": "~2.3 || ~3.0",
+        "symfony/monolog-bundle": "~2.3 || ~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Drop support for php 5.4 and 5.5
- Add travis for php 7.1
- Changed symfony version to 2.7 and 3.2

More details https://github.com/SimpleBus/MessageBus/pull/68