### PR TITLE
Add auto-register compiler pass

### DIFF
--- a/doc/command_bus_bundle.md
+++ b/doc/command_bus_bundle.md
@@ -64,6 +64,14 @@ services:
             - { name: command_handler, handles: Fully\Qualified\Class\Name\Of\RegisterUser }
 ```
 
+### Auto-Register command handlers
+
+You can omit the `handles` tag attribute if your handler meets the following conditions:
+
+1. Uses the "class_based" command name resolving strategy
+2. Handles a single command using the `__invoke` method
+3. Has a single, non optional class type hinted `__invoke` method parameter
+
 > #### Command handlers are lazy-loaded
 >
 > Since only one of the command handlers is going to handle any particular command, command handlers are lazy-loaded.

--- a/doc/event_bus_bundle.md
+++ b/doc/event_bus_bundle.md
@@ -65,6 +65,14 @@ services:
             - { name: event_subscriber, subscribes_to: Fully\Qualified\Class\Name\Of\UserRegistered }
 ```
 
+### Auto-Register event subscribers
+
+You can omit the `subscribes_to` tag attribute if your subscriber meets the following conditions:
+
+1. Uses the "class_based" event name resolving strategy
+2. Subscribers to single event using the `__invoke` method
+3. Has a single, non optional class type hinted `__invoke` method parameter
+
 > #### Event subscribers are lazy-loaded
 >
 > Since only some of the event subscribers are going to handle any particular event, event subscribers are lazy-loaded.

--- a/src/DependencyInjection/Compiler/AutoRegister.php
+++ b/src/DependencyInjection/Compiler/AutoRegister.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AutoRegister implements CompilerPassInterface
+{
+    private $tagName;
+    private $tagAttribute;
+
+    public function __construct($tagName, $tagAttribute)
+    {
+        $this->tagName = $tagName;
+        $this->tagAttribute = $tagAttribute;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds($this->tagName) as $serviceId => $tags) {
+            foreach ($tags as $tagAttributes) {
+
+                // if tag attributes are set, skip
+                if (isset($tagAttributes[$this->tagAttribute])) {
+                    continue;
+                }
+
+                $definition = $container->getDefinition($serviceId);
+
+                // check if service id is class name
+                $reflectionClass = new \ReflectionClass($definition->getClass() ?: $serviceId);
+
+                // if no __invoke method, skip
+                if (!$reflectionClass->hasMethod('__invoke')) {
+                    continue;
+                }
+
+                $invokeParameters = $reflectionClass->getMethod('__invoke')->getParameters();
+
+                // if no param or optional param, skip
+                if (count($invokeParameters) !== 1 || $invokeParameters[0]->isOptional()) {
+                    return;
+                }
+
+                // get the class name
+                $handles = $invokeParameters[0]->getClass()->getName();
+
+                // auto handle
+                $definition->clearTag($this->tagName);
+                $definition->addTag($this->tagName, [$this->tagAttribute => $handles]);
+            }
+        }
+    }
+}

--- a/src/SimpleBusCommandBusBundle.php
+++ b/src/SimpleBusCommandBusBundle.php
@@ -3,8 +3,10 @@
 namespace SimpleBus\SymfonyBridge;
 
 use SimpleBus\SymfonyBridge\DependencyInjection\CommandBusExtension;
+use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\AutoRegister;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\ConfigureMiddlewares;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterHandlers;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -32,6 +34,12 @@ class SimpleBusCommandBusBundle extends Bundle
                 'command_handler',
                 'handles'
             )
+        );
+
+        $container->addCompilerPass(
+            new AutoRegister('command_handler', 'handles'),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            10
         );
     }
 

--- a/src/SimpleBusCommandBusBundle.php
+++ b/src/SimpleBusCommandBusBundle.php
@@ -22,6 +22,12 @@ class SimpleBusCommandBusBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(
+            new AutoRegister('command_handler', 'handles'),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            10
+        );
+
+        $container->addCompilerPass(
             new ConfigureMiddlewares(
                 'command_bus',
                 'command_bus_middleware'
@@ -34,12 +40,6 @@ class SimpleBusCommandBusBundle extends Bundle
                 'command_handler',
                 'handles'
             )
-        );
-
-        $container->addCompilerPass(
-            new AutoRegister('command_handler', 'handles'),
-            PassConfig::TYPE_BEFORE_OPTIMIZATION,
-            10
         );
     }
 

--- a/src/SimpleBusEventBusBundle.php
+++ b/src/SimpleBusEventBusBundle.php
@@ -29,6 +29,12 @@ class SimpleBusEventBusBundle extends Bundle
         $this->checkRequirements(array('SimpleBusCommandBusBundle'), $container);
 
         $container->addCompilerPass(
+            new AutoRegister('event_subscriber', 'subscribes_to'),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            10
+        );
+
+        $container->addCompilerPass(
             new ConfigureMiddlewares(
                 'event_bus',
                 'event_bus_middleware'
@@ -57,12 +63,6 @@ class SimpleBusEventBusBundle extends Bundle
                 ['command'],
                 200
             )
-        );
-
-        $container->addCompilerPass(
-            new AutoRegister('event_subscriber', 'subscribes_to'),
-            PassConfig::TYPE_BEFORE_OPTIMIZATION,
-            10
         );
     }
 

--- a/src/SimpleBusEventBusBundle.php
+++ b/src/SimpleBusEventBusBundle.php
@@ -3,11 +3,13 @@
 namespace SimpleBus\SymfonyBridge;
 
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\AddMiddlewareTags;
+use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\AutoRegister;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\CompilerPassUtil;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\ConfigureMiddlewares;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterMessageRecorders;
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\RegisterSubscribers;
 use SimpleBus\SymfonyBridge\DependencyInjection\EventBusExtension;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -55,6 +57,12 @@ class SimpleBusEventBusBundle extends Bundle
                 ['command'],
                 200
             )
+        );
+
+        $container->addCompilerPass(
+            new AutoRegister('event_subscriber', 'subscribes_to'),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            10
         );
     }
 

--- a/tests/Functional/SmokeTest/Auto/AutoCommand.php
+++ b/tests/Functional/SmokeTest/Auto/AutoCommand.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto;
+
+final class AutoCommand
+{
+}

--- a/tests/Functional/SmokeTest/Auto/AutoCommandHandler.php
+++ b/tests/Functional/SmokeTest/Auto/AutoCommandHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto;
+
+final class AutoCommandHandler
+{
+    public $handled;
+
+    public function __invoke(AutoCommand $command)
+    {
+        $this->handled = $command;
+    }
+}

--- a/tests/Functional/SmokeTest/Auto/AutoEvent.php
+++ b/tests/Functional/SmokeTest/Auto/AutoEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto;
+
+final class AutoEvent
+{
+}

--- a/tests/Functional/SmokeTest/Auto/AutoEventSubscriber.php
+++ b/tests/Functional/SmokeTest/Auto/AutoEventSubscriber.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto;
+
+final class AutoEventSubscriber
+{
+    public $handled;
+
+    public function __invoke(AutoEvent $event)
+    {
+        $this->handled = $event;
+    }
+}

--- a/tests/Functional/SmokeTest/TestKernel.php
+++ b/tests/Functional/SmokeTest/TestKernel.php
@@ -18,8 +18,7 @@ class TestKernel extends Kernel
     {
         parent::__construct($environment, $debug);
 
-        $this->tempDir = sys_get_temp_dir() . '/' . uniqid();
-        mkdir($this->tempDir, 0777, true);
+        $this->tempDir = sys_get_temp_dir() . '/simplebus-symfony-bridge';
     }
 
     public function registerBundles()
@@ -35,7 +34,7 @@ class TestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__ . '/config.yml');
+        $loader->load(sprintf('%s/%s.yml', __DIR__, $this->environment));
     }
 
     public function getCacheDir()

--- a/tests/Functional/SmokeTest/config.yml
+++ b/tests/Functional/SmokeTest/config.yml
@@ -1,37 +1,6 @@
-parameters:
-    log_file: %kernel.logs_dir%/%kernel.environment%.log
-
 services:
     annotation_reader:
         class: Doctrine\Common\Annotations\AnnotationReader
-
-    test_command_handler:
-        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommandHandler
-        arguments:
-            - '@doctrine.orm.default_entity_manager'
-        tags:
-            - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommand }
-
-    some_other_test_command_handler:
-        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommandHandler
-        arguments:
-            - '@event_recorder'
-        tags:
-            - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommand }
-
-    test_event_subscriber:
-        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestEntityCreatedEventSubscriber
-        tags:
-            - { name: event_subscriber, subscribes_to: test_entity_created }
-        arguments:
-            - '@command_bus'
-
-    some_other_event_subscriber:
-        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherEventSubscriber
-        tags:
-            - { name: event_subscriber, subscribes_to: some_other_event }
-        arguments:
-            - '@command_bus'
 
 doctrine:
     dbal:
@@ -49,18 +18,3 @@ doctrine:
                         prefix: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Entity
                         alias: Test
                         is_bundle: false
-
-command_bus:
-    command_name_resolver_strategy: class_based
-    logging: ~
-
-event_bus:
-    event_name_resolver_strategy: named_message
-    logging: ~
-
-monolog:
-    handlers:
-        main:
-            type:  stream
-            path:  %log_file%
-            level: debug

--- a/tests/Functional/SmokeTest/config1.yml
+++ b/tests/Functional/SmokeTest/config1.yml
@@ -1,0 +1,49 @@
+imports:
+    - { resource: config.yml }
+
+parameters:
+    log_file: %kernel.logs_dir%/%kernel.environment%.log
+
+services:
+    test_command_handler:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommandHandler
+        arguments:
+            - '@doctrine.orm.default_entity_manager'
+        tags:
+            - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommand }
+
+    some_other_test_command_handler:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommandHandler
+        arguments:
+            - '@event_recorder'
+        tags:
+            - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommand }
+
+    test_event_subscriber:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestEntityCreatedEventSubscriber
+        tags:
+            - { name: event_subscriber, subscribes_to: test_entity_created }
+        arguments:
+            - '@command_bus'
+
+    some_other_event_subscriber:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherEventSubscriber
+        tags:
+            - { name: event_subscriber, subscribes_to: some_other_event }
+        arguments:
+            - '@command_bus'
+
+command_bus:
+    command_name_resolver_strategy: class_based
+    logging: ~
+
+event_bus:
+    event_name_resolver_strategy: named_message
+    logging: ~
+
+monolog:
+    handlers:
+        main:
+            type:  stream
+            path:  %log_file%
+            level: debug

--- a/tests/Functional/SmokeTest/config2.yml
+++ b/tests/Functional/SmokeTest/config2.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: config.yml }
+
+services:
+    auto_command_handler:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoCommandHandler
+        tags:
+            - { name: command_handler }
+
+    auto_event_subscriber:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriber
+        tags:
+            - { name: event_subscriber }


### PR DESCRIPTION
This is an alternative to #40/#39.

This allows you to leave off the `subscribes_to` and `handles` tag attribute for subscribers/handlers that meet the following conditions:

1. Does not already have `subscribes_to`/`handles` tag parameters
2. Uses `__invoke`
3. Has a single, non optional class type hinted `__invoke` method parameter

The compiler pass auto-adds the proper `subscribes_to`/`handles` tag parameter.

In Symfony 3.3, it allows you to simply have this as your config:

```yaml
services:
    App\Domain\User\CommandHandler\:
        resource: ../../src/Domain/User/CommandHandler
        tags: [command_handler]

    App\Domain\User\EventSubscriber\:
        resource: ../../src/Domain/User/EventSubscriber
        tags: [event_subscriber]
```