### PR TITLE
Allow symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 7.1
       env: SYMFONY_VERSION=3.3.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.1
+      env: SYMFONY_VERSION=4.0.*
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "symfony/http-kernel": "~2.3 || ~3.0 || ~4.0",
         "symfony/dependency-injection": "~2.3 || ~3.0 || ~4.0",
         "symfony/yaml": "~2.3 || ~3.0 || ~4.0",
-        "symfony/config": "~2.3 || ~3.0 || ~4.0"
+        "symfony/config": "~2.3 || ~3.0 || ~4.0",
+        "symfony/proxy-manager-bridge": "~2.3 || ~3.0 || ~4.0"
     },
     "suggest": {
         "simple-bus/doctrine-orm-bridge": "For integration with Doctrine ORM",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "simple-bus/message-bus": "~3.0",
-        "symfony/http-kernel": "~2.3 || ~3.0",
-        "symfony/dependency-injection": "~2.3 || ~3.0",
-        "symfony/yaml": "~2.3 || ~3.0",
-        "symfony/config": "~2.3 || ~3.0"
+        "symfony/http-kernel": "~2.3 || ~3.0 || ~4.0",
+        "symfony/dependency-injection": "~2.3 || ~3.0 || ~4.0",
+        "symfony/yaml": "~2.3 || ~3.0 || ~4.0",
+        "symfony/config": "~2.3 || ~3.0 || ~4.0"
     },
     "suggest": {
         "simple-bus/doctrine-orm-bridge": "For integration with Doctrine ORM",
@@ -35,8 +35,8 @@
         "simple-bus/doctrine-orm-bridge": "~5.0",
         "doctrine/orm": "~2.3",
         "doctrine/doctrine-bundle": "~1.0",
-        "symfony/monolog-bridge": "~2.3 || ~3.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0"
+        "symfony/monolog-bridge": "~2.3 || ~3.0 || ~4.0",
+        "symfony/monolog-bundle": "~2.3 || ~3.0 || ~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/monolog-bundle": "For logging messages"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.0 || ~5.0",
         "simple-bus/doctrine-orm-bridge": "~5.0",
         "doctrine/orm": "~2.3",
         "doctrine/doctrine-bundle": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/orm": "~2.3",
         "doctrine/doctrine-bundle": "~1.0",
         "symfony/monolog-bridge": "~2.3 || ~3.0 || ~4.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0 || ~4.0"
+        "symfony/monolog-bundle": "~2.3 || ~3.0 "
     },
     "autoload": {
         "psr-4": {

--- a/src/DependencyInjection/DoctrineOrmBridgeExtension.php
+++ b/src/DependencyInjection/DoctrineOrmBridgeExtension.php
@@ -9,6 +9,8 @@ use Symfony\Component\Config\FileLocator;
 
 class DoctrineOrmBridgeExtension extends ConfigurableExtension
 {
+    private $alias;
+
     public function __construct($alias)
     {
         $this->alias = $alias;

--- a/src/DependencyInjection/EventBusExtension.php
+++ b/src/DependencyInjection/EventBusExtension.php
@@ -10,6 +10,8 @@ use Symfony\Component\Config\FileLocator;
 
 class EventBusExtension extends ConfigurableExtension
 {
+    private $alias;
+
     public function __construct($alias)
     {
         $this->alias = $alias;

--- a/src/Resources/config/command_bus.yml
+++ b/src/Resources/config/command_bus.yml
@@ -1,6 +1,7 @@
 services:
     command_bus:
         alias: simple_bus.command_bus
+        public: true
 
     simple_bus.command_bus:
         class: SimpleBus\SymfonyBridge\Bus\CommandBus

--- a/src/Resources/config/event_bus.yml
+++ b/src/Resources/config/event_bus.yml
@@ -1,6 +1,7 @@
 services:
     event_bus:
         alias: simple_bus.event_bus
+        public: true
 
     simple_bus.event_bus:
         class: SimpleBus\SymfonyBridge\Bus\EventBus

--- a/tests/Functional/SmokeTest/config1.yml
+++ b/tests/Functional/SmokeTest/config1.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: config.yml }
 
 parameters:
-    log_file: %kernel.logs_dir%/%kernel.environment%.log
+    log_file: '%kernel.logs_dir%/%kernel.environment%.log'
 
 services:
     test_command_handler:
@@ -11,6 +11,7 @@ services:
             - '@doctrine.orm.default_entity_manager'
         tags:
             - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestCommand }
+        public: true
 
     some_other_test_command_handler:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommandHandler
@@ -18,6 +19,7 @@ services:
             - '@event_recorder'
         tags:
             - { name: command_handler, handles: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherTestCommand }
+        public: true
 
     test_event_subscriber:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestEntityCreatedEventSubscriber
@@ -25,6 +27,7 @@ services:
             - { name: event_subscriber, subscribes_to: test_entity_created }
         arguments:
             - '@command_bus'
+        public: true
 
     some_other_event_subscriber:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\SomeOtherEventSubscriber
@@ -32,6 +35,7 @@ services:
             - { name: event_subscriber, subscribes_to: some_other_event }
         arguments:
             - '@command_bus'
+        public: true
 
 command_bus:
     command_name_resolver_strategy: class_based
@@ -45,5 +49,5 @@ monolog:
     handlers:
         main:
             type:  stream
-            path:  %log_file%
+            path:  '%log_file%'
             level: debug

--- a/tests/Functional/SmokeTest/config2.yml
+++ b/tests/Functional/SmokeTest/config2.yml
@@ -6,18 +6,22 @@ services:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoCommandHandlerUsingInvoke
         tags:
             - { name: command_handler }
+        public: true
 
     auto_command_handler_using_public_method:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoCommandHandlerUsingPublicMethod
         tags:
             - { name: command_handler, register_public_methods: true }
+        public: true
 
     auto_event_subscriber_using_invoke:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriberUsingInvoke
         tags:
             - { name: event_subscriber }
+        public: true
 
     auto_event_subscriber_using_public_method:
         class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriberUsingPublicMethod
         tags:
             - { name: event_subscriber, register_public_methods: true }
+        public: true

--- a/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
+++ b/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
@@ -3,6 +3,9 @@
 namespace SimpleBus\SymfonyBridge\Tests\SymfonyBundle\DependencyInjection\Compiler;
 
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\ConfigureMiddlewares;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent1;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent2;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent3;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Kernel;
@@ -37,9 +40,9 @@ class ConfigureMiddlewaresTest extends \PHPUnit_Framework_TestCase
     public function it_configures_a_chain_of_buses_according_to_the_given_priorities()
     {
         $classes = [
-            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent1' => 100,
-            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent2' => -100,
-            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent3' => 200,
+            AuteEvent1::class => 100,
+            AuteEvent2::class => -100,
+            AuteEvent3::class => 200,
         ];
 
         foreach ($classes as $class => $priority) {

--- a/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
+++ b/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
@@ -81,7 +81,7 @@ class ConfigureMiddlewaresTest extends \PHPUnit_Framework_TestCase
                     'Symfony\Component\DependencyInjection\Reference',
                     $referencedService
                 );
-                $referencedService = $this->container->getDefition((string) $referencedService);
+                $referencedService = $this->container->getDefinition((string) $referencedService);
             }
 
             $actualMiddlewareClasses[$referencedService->getClass()] = $referencedService->getTag('middleware')[0]['priority'];

--- a/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
+++ b/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
@@ -5,6 +5,7 @@ namespace SimpleBus\SymfonyBridge\Tests\SymfonyBundle\DependencyInjection\Compil
 use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\ConfigureMiddlewares;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\Kernel;
 
 class ConfigureMiddlewaresTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,41 +36,57 @@ class ConfigureMiddlewaresTest extends \PHPUnit_Framework_TestCase
      */
     public function it_configures_a_chain_of_buses_according_to_the_given_priorities()
     {
-        $this->createBusDefinition('middleware100', 100);
-        $this->createBusDefinition('middleware-100', -100);
-        $this->createBusDefinition('middleware200', 200);
+        $classes = [
+            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent1' => 100,
+            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent2' => -100,
+            'SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AuteEvent3' => 200,
+        ];
+
+        foreach ($classes as $class => $priority) {
+            $this->createBusDefinition($class, $priority);
+        }
 
         $this->container->compile();
 
-        $this->commandBusContainsMiddlewares(array('middleware200', 'middleware100', 'middleware-100'));
+        $this->commandBusContainsMiddlewares($classes);
     }
 
-    private function createBusDefinition($id, $priority)
+    private function createBusDefinition($class, $priority)
     {
-        $definition = new Definition('stdClass');
+        $definition = new Definition($class);
         $definition->addTag($this->middlewareTag, array('priority' => $priority));
 
-        $this->container->setDefinition($id, $definition);
+        $this->container->setDefinition($class, $definition);
 
         return $definition;
     }
 
-    private function commandBusContainsMiddlewares($expectedMiddlewareIds)
+    private function commandBusContainsMiddlewares($expectedMiddlewareclasses)
     {
-        $actualMiddlewareIds = [];
+        $actualMiddlewareClasses = [];
 
         foreach ($this->mainBusDefinition->getMethodCalls() as $methodCall) {
             list($method, $arguments) = $methodCall;
             $this->assertSame('appendMiddleware', $method);
             $this->assertCount(1, $arguments);
             $referencedService = $arguments[0];
-            $this->assertInstanceOf(
-                'Symfony\Component\DependencyInjection\Reference',
-                $referencedService
-            );
-            $actualMiddlewareIds[] = (string) $referencedService;
+
+            if (Kernel::VERSION_ID >= 40000) {
+                $this->assertInstanceOf(
+                    'Symfony\Component\DependencyInjection\Definition',
+                    $referencedService
+                );
+            } else {
+                $this->assertInstanceOf(
+                    'Symfony\Component\DependencyInjection\Reference',
+                    $referencedService
+                );
+                $referencedService = $this->container->getDefition((string) $referencedService);
+            }
+
+            $actualMiddlewareClasses[$referencedService->getClass()] = $referencedService->getTag('middleware')[0]['priority'];
         }
 
-        $this->assertEquals($expectedMiddlewareIds, $actualMiddlewareIds);
+        $this->assertEquals($expectedMiddlewareclasses, $actualMiddlewareClasses);
     }
 }


### PR DESCRIPTION
PR to enable usage on symfony 4.

I mention that I've added as a dependency **symfony/proxy-manager-bridge** because symfony/doctrine-bridge as of version 4 throws an exception when the resetting the entity manager (https://github.com/SimpleBus/DoctrineORMBridge/blob/master/src/MessageBus/WrapsMessageHandlingInTransaction.php#L44): 
https://github.com/symfony/doctrine-bridge/blob/4.0/ManagerRegistry.php#L50 vs https://github.com/symfony/doctrine-bridge/blob/3.3/ManagerRegistry.php#L48