### PR TITLE
Remove the minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,5 @@
         "psr-4": {
             "SimpleBus\\SymfonyBridge\\Tests\\": "tests"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
This seems to fix the memory issue on php 5.6