### PR TITLE
Remove PHPUnit forward compatibility layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 before_install:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/http-kernel:$SYMFONY_VERSION symfony/dependency-injection:$SYMFONY_VERSION symfony/yaml:$SYMFONY_VERSION symfony/config:$SYMFONY_VERSION symfony/monolog-bridge:$SYMFONY_VERSION; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:$SYMFONY_VERSION; fi
 
 install:
   - composer install --prefer-dist

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,9 +6,3 @@ require __DIR__ . '/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader('class_exists');
 
-// Polyfill PHPUnit 6.0 both ways
-if (!class_exists('\PHPUnit\Framework\TestCase', true)) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-} elseif (!class_exists('\PHPUnit_Framework_TestCase', true)) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}


### PR DESCRIPTION
PHPUnit 5.7.0+ ship his own forward compatibility layer. This remove the one shipped with this library because it mess-up PHPStorm indexation and is not required.