### PR TITLE
Do not distribuite tests directory with package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 /phpunit.xml        export-ignore
 /phpunit.xml.dist   export-ignore
 /composer.lock      export-ignore
+/tests              export-ignore


### PR DESCRIPTION
Apart for being superfluous in distribution, current bootstrap.php file is causing autocompletion problems (by trying to polyfill phpunit TestCase class)