### PR TITLE
Ignore public methods with a single non-class argument in AutoRegister

### DIFF
--- a/src/DependencyInjection/Compiler/AutoRegister.php
+++ b/src/DependencyInjection/Compiler/AutoRegister.php
@@ -53,8 +53,10 @@ final class AutoRegister implements CompilerPassInterface
 
                     $parameters = $method->getParameters();
 
-                    // if no param or optional param, skip
-                    if (count($parameters) !== 1 || $parameters[0]->isOptional()) {
+                    // if no param, optional param or non-class param, skip
+                    if (count($parameters) !== 1 ||
+                        $parameters[0]->isOptional() ||
+                        is_null($parameters[0]->getClass())) {
                         continue;
                     }
 

--- a/tests/Functional/SmokeTest/Auto/AutoEventSubscriberUsingPublicMethod.php
+++ b/tests/Functional/SmokeTest/Auto/AutoEventSubscriberUsingPublicMethod.php
@@ -23,4 +23,9 @@ final class AutoEventSubscriberUsingPublicMethod
     {
         $event->setHandledBy($this);
     }
+
+    public function someUnrelatedFunctionWithAnUntypesArgument($argument)
+    {
+
+    }
 }


### PR DESCRIPTION
Just ran into this issue. Pretty much self explanatory.